### PR TITLE
Remove redundant restore_unlocked function

### DIFF
--- a/crates/baza-core/src/storage.rs
+++ b/crates/baza-core/src/storage.rs
@@ -115,25 +115,6 @@ pub async fn restore(data: Vec<(String, Vec<u8>)>) -> BazaR<()> {
     .await
 }
 
-/// Restore data without requiring the vault to be unlocked
-/// This is useful for initial database restoration
-pub async fn restore_unlocked(data: Vec<(String, Vec<u8>)>) -> BazaR<()> {
-    with_backend(|backend| async move {
-        // Clear existing data
-        let keys = backend.list_keys().await?;
-        for key in keys {
-            backend.remove(&key).await?;
-        }
-
-        // Restore new data
-        for (key, value) in data {
-            backend.set(&key, value).await?;
-        }
-        Ok(())
-    })
-    .await
-}
-
 // storage.rs
 
 pub async fn search(pattern: String) -> BazaR<()> {

--- a/crates/baza-web/src/lib.rs
+++ b/crates/baza-web/src/lib.rs
@@ -409,7 +409,7 @@ pub fn app() -> Html {
                                 let uint8 = js_sys::Uint8Array::new(&buf_js);
                                 let bytes = uint8.to_vec();
                                 match baza_core::dump::restore::<Vec<(String, Vec<u8>)>>(&bytes) {
-                                    Ok(data) => match baza_core::storage::restore_unlocked(data).await {
+                                    Ok(data) => match baza_core::storage::restore(data).await {
                                         Ok(_) => {
                                             error_msg.set("RESTORE SUCCESSFUL".to_string());
                                             load_bundles.emit(());


### PR DESCRIPTION
Removed the redundant `restore_unlocked` function from `crates/baza-core/src/storage.rs` as it was identical to `restore`. Both functions operate on pre-encrypted data and do not require the vault to be unlocked, making the distinction unnecessary. Updated all call sites in the `baza-web` crate to use the simplified `restore` function. Verified that the `baza` CLI already uses `restore` and that the entire workspace compiles and passes existing tests.

---
*PR created automatically by Jules for task [7295317097267665171](https://jules.google.com/task/7295317097267665171) started by @wilful*